### PR TITLE
Fix: Use yaml.Unmarshal instead of UnmarshalStrict for config compatibility

### DIFF
--- a/cmd/hostpaths/hostpaths.go
+++ b/cmd/hostpaths/hostpaths.go
@@ -262,9 +262,10 @@ func getVclusterConfigFromSecret(ctx context.Context, kubeClient kubernetes.Inte
 		return nil, fmt.Errorf("key '%s' not found in secret", configFilename)
 	}
 
-	// create a new strict decoder
+	// Use regular Unmarshal instead of UnmarshalStrict to allow for forward compatibility
+	// with newer config fields that might not be defined in the current Config struct
 	rawConfig := &config.Config{}
-	err = yaml.UnmarshalStrict(rawBytes, rawConfig)
+	err = yaml.Unmarshal(rawBytes, rawConfig)
 	if err != nil {
 		klog.Errorf("unmarshal %s: %#+v", configFilename, errors.Unwrap(err))
 		return nil, err


### PR DESCRIPTION
## Description

This PR changes the unmarshal method from `yaml.UnmarshalStrict` to `yaml.Unmarshal` in the hostpaths.go file to allow forward compatibility with newer vCluster configurations.

## Problem

When running the hostpath-mapper with newer vCluster configurations that include fields not yet defined in the current Config struct (like "reuseNamespace"), the application fails with an error:
```
E0312 14:36:54.634840 1 hostpaths.go:269] unmarshal config.yaml: &errors.errorString{s:"while decoding JSON: json: unknown field \"reuseNamespace\""}
Error: find vcluster mode: error unmarshaling JSON: while decoding JSON: json: unknown field "reuseNamespace"
```

## Solution

By switching to `yaml.Unmarshal` instead of `yaml.UnmarshalStrict`, we allow the parser to ignore fields that are not defined in the target struct, providing forward compatibility with future vCluster configuration versions.

## Testing

Tested by running the hostpath-mapper with a configuration that includes the "reuseNamespace" field. After this change, the application starts successfully and properly processes the configuration.